### PR TITLE
adding build instructions otherwise was failing to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ Processors are the converts from openshift to kubernetes.
 
 -----------------
 
+## Build the tool
+
+Once repo downloaded, run the following to build the tool for executable file
+
+```
+ git checkout <release>  (example: release=0.12)
+ 
+ go build 
+
+```
+
+
 ## Inputs
 
 Inputs are readers for your existing Openshift application deployment methods


### PR DESCRIPTION
If we dont go with the latest release, cloning the repo and running the build throwing the following error

# shifter/generators
generators/helm.go:138:13: cannot use objects (type []lib.K8sobject) as type lib.Kube in argument to genTemplate
generators/helm.go:139:11: cannot use objects (type []lib.K8sobject) as type lib.Kube in argument to genValues

Added instructions on how to build with specific release