### PR TITLE
Use correct canonical name for the module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module shifter
+module github.com/garybowers/shifter
 
 go 1.14
 


### PR DESCRIPTION
The canonical name for this module should be `github.com/garybowers/shifter`. Details here: https://golang.org/ref/mod#module-path

In the current form, it's not possible to do `go install github.com/garybowers/shifter`.

Also, you might want to use semantic versioning for your tags to be fully compatible with the go tooling: https://golang.org/ref/mod#versions Since you're still in the pre-release stage, you can pick `v0.13.0` as your next tag, which is a semantically-correct tag for go.