### PR TITLE
Fix import paths

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -15,11 +15,12 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"log"
-	generators "shifter/generators"
-	inputs "shifter/inputs"
 	"strings"
+
+	generators "github.com/garybowers/shifter/generators"
+	inputs "github.com/garybowers/shifter/inputs"
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,8 +15,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"

--- a/generators/generator.go
+++ b/generators/generator.go
@@ -15,9 +15,10 @@ package generator
 
 import (
 	"fmt"
-	k8sjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"os"
-	"shifter/lib"
+
+	"github.com/garybowers/shifter/lib"
+	k8sjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
 func serializer(input lib.K8sobject) {

--- a/generators/helm.go
+++ b/generators/helm.go
@@ -15,13 +15,16 @@ package generator
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"log"
 	"os"
+
+	"gopkg.in/yaml.v3"
+
 	//"reflect"
 	"regexp"
-	lib "shifter/lib"
 	"strconv"
+
+	lib "github.com/garybowers/shifter/lib"
 )
 
 type Chart struct {

--- a/generators/yaml.go
+++ b/generators/yaml.go
@@ -16,12 +16,13 @@ package generator
 import (
 	"bufio"
 	"fmt"
-	k8sjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"log"
 	"os"
 	"path/filepath"
-	"shifter/lib"
 	"strconv"
+
+	"github.com/garybowers/shifter/lib"
+	k8sjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
 func Yaml(path string, objects []lib.K8sobject) {

--- a/inputs/template.go
+++ b/inputs/template.go
@@ -19,10 +19,10 @@ import (
 	//"gopkg.in/yaml.v3"
 	"io/ioutil"
 	//"log"
-	//"shifter/processor"
+	//"github.com/garybowers/shifter/processor"
 	"sigs.k8s.io/yaml"
 	//v1 "github.com/openshift/api/template/v1"
-	lib "shifter/lib"
+	lib "github.com/garybowers/shifter/lib"
 )
 
 type OSTemplate struct {

--- a/inputs/yaml.go
+++ b/inputs/yaml.go
@@ -2,16 +2,17 @@ package input
 
 import (
 	"fmt"
-	gyaml "github.com/ghodss/yaml"
-	yaml "gopkg.in/yaml.v3"
 	"io"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
-	"shifter/lib"
-	"shifter/processor"
 	"strings"
+
+	"github.com/garybowers/shifter/lib"
+	"github.com/garybowers/shifter/processor"
+	gyaml "github.com/ghodss/yaml"
+	yaml "gopkg.in/yaml.v3"
 	//"regexp"
 )
 

--- a/processor/deploymentconfig.go
+++ b/processor/deploymentconfig.go
@@ -14,12 +14,13 @@ limitations under the license.
 package processor
 
 import (
+	"log"
+	"strings"
+
 	osappsv1 "github.com/openshift/api/apps/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"log"
-	"strings"
 )
 
 func convertDeploymentConfigToDeployment(OSDeploymentConfig osappsv1.DeploymentConfig, flags map[string]string) appsv1.Deployment {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -16,13 +16,14 @@ package processor
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+
+	"github.com/garybowers/shifter/lib"
 	osappsv1 "github.com/openshift/api/apps/v1"
 	osroutev1 "github.com/openshift/api/route/v1"
 	apiv1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	kjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
-	"os"
-	"shifter/lib"
 )
 
 func int32Ptr(i int32) *int32 { return &i }

--- a/shifter.go
+++ b/shifter.go
@@ -13,7 +13,7 @@ limitations under the License.
 
 package main
 
-import "shifter/cmd"
+import "github.com/garybowers/shifter/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
These changes are required after #10. I got a bit too eager there :) Also, I took the liberty to run goimports on the code.

BTW, it looks like there's some build issue due to a wrong type being passed around to Helm [here](https://github.com/garybowers/shifter/blob/d2896c3ba4aa4d55407c7253a819390a4c0ed242/generators/helm.go#L135). Initially, this code was using `lib.Kube`, which is what `genTemplate` and `genValues` expect. It was later changed to `[]lib.K8sobject` so it accepts the data  returned by`inputs.Yaml`, but it looks like that refactor wasn't finalised.